### PR TITLE
Remove PACKAGE_DATA from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,7 @@ CLASSIFIERS = [
 PLATFORMS = "Any"
 PACKAGES = find_packages(exclude=["doc"])
 SCRIPTS = []
-PACKAGE_DATA = {
-    "harmonica.datasets": ["registry.txt"],
-    "harmonica.tests": ["data/*", "baseline/*"],
-}
+PACKAGE_DATA = {}
 INSTALL_REQUIRES = [
     "numpy",
     "scipy",


### PR DESCRIPTION
The setup.py file used to keep some files inside PACKAGE_DATA variable that don't exist
on this package.