### PR TITLE
Add templates for GitHub Issues and Pull Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a problem/bug to help us improve
+
+---
+
+**Description of the problem**
+
+<!-- Please be as detailed as you can when describing an issue. The more information we have, the easier it will be for us to track this down. -->
+
+**Full code that generated the error**
+
+<!-- Include any data files or inputs required to run the code. It really helps if we can run the code on our own machines. -->
+
+```python
+PASTE CODE HERE
+```
+
+**Full error message**
+
+```
+PASTE ERROR MESSAGE HERE
+```
+
+**System information**
+
+* Operating system:
+* Python installation (Anaconda, system, ETS):
+* Version of Python:
+* Version of this package:
+* If using conda, paste the output of `conda list` below:
+
+<details>
+<summary>output of conda list</summary>
+<pre>
+PASTE OUTPUT OF CONDA LIST HERE
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Request the addition of a new feature/functionality
+
+---
+
+**Description of the desired feature**
+
+
+
+<!-- Please be as detailed as you can in your description. If possible, include an example of how you would like to use this feature (even better if it's a code example). -->
+
+
+**Are you willing to help implement and maintain this feature?** Yes/No
+
+<!-- Every feature we add is code that we will have to maintain and keep updated. This takes a lot of effort. If you are willing to be involved in the project and help maintain your feature, it will make it easier for us to accept it. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->
+
+<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
+Fixes #
+
+
+**Reminders**
+
+- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
+- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
+- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
+- [ ] Write detailed docstrings for all functions/methods.
+- [ ] If adding new functionality, add an example to the `examples`.
+- [ ] If new dependency is required, add it to `environment.yml`, `requirements.txt`, `setup.py` and `requirements-dev.txt` (if it's a development dependency).


### PR DESCRIPTION
Add templates for new GitHub Pull Requests and two types of Issues: Bug Report and Feature Request.
Based on the templates of https://github.com/fatiando/harmonica.