### PR TITLE
Add path and fname in temperature save function

### DIFF
--- a/modelling_earth/io/temperature.py
+++ b/modelling_earth/io/temperature.py
@@ -1,6 +1,7 @@
 """
 Save temperature distributions to ASCII files to be read by MD3D
 """
+import os
 import numpy as np
 
 HEADER = "T1 \n T2 \n T3 \n T4"
@@ -45,4 +46,6 @@ def save_temperature(temperatures, path, fname=FNAME):
     # We will use order "F" on numpy.ravel in order to make the first index to change
     # faster than the rest
     # Will add a custom header required by MD3D
-    np.savetxt(fname, temperatures.values.ravel(order="F"), header=HEADER)
+    np.savetxt(
+        os.path.join(path, fname), temperatures.values.ravel(order="F"), header=HEADER
+    )

--- a/modelling_earth/io/temperature.py
+++ b/modelling_earth/io/temperature.py
@@ -4,9 +4,10 @@ Save temperature distributions to ASCII files to be read by MD3D
 import numpy as np
 
 HEADER = "T1 \n T2 \n T3 \n T4"
+FNAME = "Temper_0_3D.txt"
 
 
-def save_temperature(temperatures, fname):
+def save_temperature(temperatures, path, fname=FNAME):
     """
     Save temperatures grid as ASCII file ready to be read by MD3D
 
@@ -18,8 +19,10 @@ def save_temperature(temperatures, fname):
     ----------
     temperatures : :class:`xarray.DataArray`
         Array containing a temperature distribution. Can be either 2D or 3D.
-    fname :
-       Filename of the output ASCII file.
+    path : str
+        Path to save the temperature file.
+    fname : str (optional)
+       Filename of the output ASCII file. Deault to ``Temper_0_3D.txt``.
     """
     # Check if temperatures is 2D or 3D
     dimension = len(temperatures.dims)


### PR DESCRIPTION
In  ``save_temperature`` add the path to the directory where the temperatures file must be saved, and an optional fname argument for the filename.
Fixes #40 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the `examples`.
- [ ] If new dependency is required, add it to `environment.yml`, `requirements.txt`, `setup.py` and `requirements-dev.txt` (if it's a development dependency).
