### PR TITLE
Transpose temperature when saving ASCII file

### DIFF
--- a/examples/interface_temperature_3d.py
+++ b/examples/interface_temperature_3d.py
@@ -53,3 +53,6 @@ layers = {
 
 # Save the interfaces to an ASCII file
 me.save_interfaces(interfaces, layers, md3d_input_path)
+
+# Save temperatures to an ASCII file
+me.save_temperature(temperature, md3d_input_path)

--- a/modelling_earth/io/temperature.py
+++ b/modelling_earth/io/temperature.py
@@ -36,12 +36,16 @@ def save_temperature(temperatures, path, fname=FNAME):
             "Invalid temperatures array with dimension {}: ".format(dimension)
             + "must be either 2 or 3."
         )
-    # Check if temperature dims are in the correct order
-    if temperatures.dims != expected_dims:
+    # Check if temperature dims are the right ones
+    invalid_dims = [dim for dim in temperatures.dims if dim not in expected_dims]
+    if invalid_dims:
         raise ValueError(
-            "Invalid temperature dimensions '{}': ".format(temperatures.dims)
+            "Found invalid temperature dimensions '{}': ".format(invalid_dims)
             + "must be '{}' for {}D temperatures.".format(expected_dims, dimension)
         )
+    # Change order of temperature dimensions to ("x", "y", "z") or ("x", "z") to ensure
+    # right order of elements when the array is ravelled
+    temperatures = temperatures.transpose(*expected_dims)
     # Ravel and save temperatures
     # We will use order "F" on numpy.ravel in order to make the first index to change
     # faster than the rest

--- a/modelling_earth/temperature.py
+++ b/modelling_earth/temperature.py
@@ -174,4 +174,5 @@ def subducting_slab_temperature(
         ),
         temperatures,
     )
+    temperatures = temperatures.transpose("x", "y", "z")
     return temperatures

--- a/modelling_earth/temperature.py
+++ b/modelling_earth/temperature.py
@@ -174,5 +174,4 @@ def subducting_slab_temperature(
         ),
         temperatures,
     )
-    temperatures = temperatures.transpose("x", "y", "z")
     return temperatures


### PR DESCRIPTION
Transpose dimensions of temperature array to the correct order: (x, y, z) for 3D and (x, z) for 2D. 



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the `examples`.
- [ ] If new dependency is required, add it to `environment.yml`, `requirements.txt`, `setup.py` and `requirements-dev.txt` (if it's a development dependency).
